### PR TITLE
Replace 0.0 with 0

### DIFF
--- a/find_peaks
+++ b/find_peaks
@@ -410,7 +410,7 @@ sub load_gff {
 		
 		next unless $start;
 		
-		$score = 0 if $score eq "NA";
+		$score = 0 if $score eq "NA" or $score eq "0.0";
 		
 		push (@$in_ref, [$chr, $start, $end, $score]);
 	}
@@ -436,7 +436,6 @@ sub find_quants {
 	foreach my $l (@$in_ref) {	
 		my ($chr, $start, $end, $score) = @$l;
 		next unless $score;
-		$score = 0 if $score eq "NA";
 		$total_coverage += $end-$start;
 		push @frags, $score;
 	}


### PR DESCRIPTION
Hi @owenjm,

I was averaging score files in pandas, which writes out `0` as `0.0` and noticed that we were getting different results based on whether the score column had 0 or 0.0 as value.

Not being fluent in perl I have no clue why this is important or if this is the correct way to do it, but replacing `0.0` with `0` solved the issue for us

Also the previous NA replacement appeared twice, I guess it'd be enough to just do this once ?